### PR TITLE
Add missing <limits> include to List.h

### DIFF
--- a/rct/List.h
+++ b/rct/List.h
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
Discovered while compiling rtags with GCC11.1.0